### PR TITLE
use id card number as revocationKey

### DIFF
--- a/src/id-card/index.html
+++ b/src/id-card/index.html
@@ -223,7 +223,7 @@
                     },
                     saveIdCard: function () {
                         console.log('saveIdCard');
-                        this.idCardToIssue['revocationKey'] = luxon.DateTime.now().toUTC().toMillis().toString();
+                        this.idCardToIssue['revocationKey'] = this.idCardToIssue.number;
                         const self = this;
                         return irmaIssueCredential(CREDENTIAL.ID_CARD_ID_CARD, this.idCardToIssue, HEADER_MESSAGES.ISSUE_ID_CARD_ID_CARD)
                             .then((_) => {


### PR DESCRIPTION
The bug in irmago server has been fixed by SIDN so we can use id card number as the revocation key again.